### PR TITLE
Add FastAPI search aggregator app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+- Initial creation of project skeleton.
+- Added FastAPI web app with mocked search aggregation.
+- Added simple HTML form and results rendering without external templates.
+- Updated README with instructions.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# oaic_test
+# Search Aggregator App
+
+This repository contains a simple FastAPI application that collects search results from multiple search engines. Due to the execution environment's lack of network access, the app returns mocked search results for demonstration purposes.
+
+## Running the app
+
+```bash
+python search_app/main.py
+```
+
+Then open `http://localhost:8000/` in your browser.
+

--- a/search_app/main.py
+++ b/search_app/main.py
@@ -1,0 +1,66 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from typing import List, Dict
+
+app = FastAPI()
+
+# Stub function to simulate search engine results
+def search_engine(name: str, query: str) -> List[Dict[str, str]]:
+    results = []
+    for i in range(1, 16):
+        results.append({
+            'title': f'{name} Result {i} for {query}',
+            'url': f'https://{name.lower()}.com/search?q={query}&result={i}',
+            'score': 1.0 / i
+        })
+    return results
+
+
+def aggregate_results(query: str) -> List[Dict[str, str]]:
+    engines = ['Google', 'Bing', 'DuckDuckGo', 'Brave']
+    all_results = []
+    for engine in engines:
+        all_results.extend(search_engine(engine, query))
+    all_results.sort(key=lambda x: x['score'], reverse=True)
+    return all_results[:5]
+
+
+FORM = """
+<!DOCTYPE html>
+<html>
+<head><title>Search Aggregator</title></head>
+<body>
+    <h1>Search Aggregator</h1>
+    <form method='get'>
+        <input type='text' name='q' value='{query}' required>
+        <button type='submit'>Search</button>
+    </form>
+    {results}
+</body>
+</html>
+"""
+
+
+def render_results(query: str, results: List[Dict[str, str]]) -> str:
+    if not results:
+        return ""
+    items = ''.join(
+        f"<li><a href='{r['url']}'>{r['title']}</a> - score {r['score']:.2f}</li>"
+        for r in results
+    )
+    return f"<h2>Top Results for '{query}'</h2><ul>{items}</ul>"
+
+
+@app.get('/', response_class=HTMLResponse)
+async def get_form(q: str | None = None):
+    query = q or ''
+    results_html = ''
+    if q:
+        results = aggregate_results(q)
+        results_html = render_results(q, results)
+    html = FORM.format(query=query, results=results_html)
+    return HTMLResponse(content=html)
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- implement a FastAPI app with a simple HTML form
- mock search results from multiple engines
- show top five results with relevance score
- document setup in README
- start a changelog

## Testing
- `python search_app/main.py` *(fails: python-multipart missing so switched to GET form)*
- `curl -s 'http://localhost:8000/?q=test'`